### PR TITLE
Bug affecting passcode and other items entered at prompt

### DIFF
--- a/src/lib/yubikey_util.c
+++ b/src/lib/yubikey_util.c
@@ -1089,7 +1089,7 @@ char *getInput(const char *prompt, int size, int required, uint8_t flags) {
         if (bytes_read >= size)
             answer[size] = '\0';
         else
-            answer[bytes_read-1] = '\0';
+            answer[bytes_read] = '\0';
     }
 
     /* restore terminal */


### PR DESCRIPTION
There is a bug in getInput() within src/lib/yubikey_util.c that causes the passcode entered to be truncated by 1 character before being saved. This affects the ykpasswd and ykvalidate binaries.

Due to both binaries sharing this code, you wouldn't notice the problem when testing the OTP/passcode with ykvalidate, but you would notice the problem when testing the OTP/passcode via yk_chkpwd.
