### PR TITLE
Added Dvorak and Colemak support.

### DIFF
--- a/README
+++ b/README
@@ -70,6 +70,24 @@ Supported PAM module parameters are:
                    passcode. This can be very handy when you are using other
                    pam modules like pam_ecryptfs.
 
+Most keyboard layouts will work out of the box, as Yubico designed the
+keypresses used by the Yubikey to be the same on many layouts (qwerty,
+azerty, etc). Some layouts, however, such as Dvorak and Colemak do not
+share the same character mapping. English Dvorak and Colemak will work
+out of the box for authentication, as will any other keymaps you add.
+
+However, when using ykpasswd with a keymap other than one compatible with
+standard modhex, you must ensure that the OTP given to -o is in modhex 
+(this is to ensure you enroll the key that you meant to.)
+
+Thus, you should either temporarily switch your keyboard layout to qwerty
+before running ykpasswd to enroll users, or use the provided layout conversion
+script contrib/convert-modhex-to-keymap.py to convert from your layout of
+choice to modhex.
+
+To add support for additional keymaps, edit utils/yk_chkpwd.c and add your
+keymap(s) of choice to the KEYMAPS array.
+
 -------------------------------------------------------------------------------
 5. Utilities
 -------------------------------------------------------------------------------

--- a/contrib/convert-modhex-to-keymap.py
+++ b/contrib/convert-modhex-to-keymap.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python
+
+import optparse
+import sys
+
+KEYMAPS = {"default":"cbdefghijklnrtuv",
+           "modhex":"default",
+           "dvorak":"jxe.uidchtnbpygk",
+           "colemak":"cbsftdhuneikpglv"}
+
+def lookup_keymap(keymap):
+  while keymap in KEYMAPS:
+    keymap = KEYMAPS[keymap]
+  assert len(keymap) == len(set(keymap)) == 16, "Invalid keymap."
+  return keymap
+
+def main():
+  parser = optparse.OptionParser()
+  parser.add_option("-d", help="Use this as destination keymap instead of default modhex.",
+                    default="default")
+  parser.set_usage("%s [-d dest_kemap] src_keymap OTP\n\t(keymaps may be a literal keymapping such as %s or a nickname such as dvorak)\n\tKnown nicknames: %s" % (sys.argv[0], KEYMAPS["default"], ', '.join(KEYMAPS)))
+  opts, argv = parser.parse_args()
+
+  if len(argv) != 2:
+    parser.print_usage()
+    return
+
+  src, opt = argv
+
+  lut = dict(zip(*map(lookup_keymap, (src, opts.d))))
+  print ''.join(map(lut.get, opt))
+
+if __name__ == "__main__":
+  main()

--- a/src/lib/yubikey_util.h
+++ b/src/lib/yubikey_util.h
@@ -49,8 +49,8 @@ int safeStrnlen(const char *buf, int buf_size);
 char *getInput(const char *prompt, int size, int required, uint8_t flags);
 int _yubi_run_helper_binary(const char *otp_passcode, const char *user, int debug);
 int checkHexString(const uint8_t *);
-int checkModHexString(const uint8_t *);
-int checkOTPCompliance(const uint8_t *, uint32_t);
+int checkModHexString(const uint8_t *, const char *);
+int checkOTPCompliance(const uint8_t *, uint32_t, const char *);
 
 /* cipher/ routines */
 void aesEncryptBlock(uint8_t *, const uint8_t *);
@@ -61,9 +61,9 @@ void getSHA256(const uint8_t *, uint32_t, uint8_t *);
 uint16_t getCRC(const uint8_t *, uint32_t);
 
 /* yubikey routines */
-uint32_t modHexDecode(uint8_t *, const uint8_t *, uint32_t);
+uint32_t modHexDecode(uint8_t *, const uint8_t *, uint32_t, const char *);
 uint32_t modHexEncode(uint8_t *, const uint8_t *, uint32_t);
-int parseOTP(yk_ticket *, uint8_t *, uint8_t *, const uint8_t *, const uint8_t *);
+int parseOTP(yk_ticket *, uint8_t *, uint8_t *, const uint8_t *, const uint8_t *, const char *);
 void printTicket(yk_ticket *);
 
 #endif

--- a/src/utils/ykdump.c
+++ b/src/utils/ykdump.c
@@ -108,8 +108,8 @@ void parseCommandLine(int argc, char *argv[]) {
                     getSHA256(public_uid_bin, public_uid_bin_size, (uint8_t *)&entry.public_uid_hash);
                     mode |= MODE_SEARCH_PUBLIC;
 
-                } else if ( !checkModHexString((const uint8_t *)optarg) ) {
-                    public_uid_bin_size = modHexDecode(public_uid_bin, (const uint8_t *)optarg, PUBLIC_UID_BYTE_SIZE);
+                } else if ( !checkModHexString((const uint8_t *)optarg, NULL) ) {
+                    public_uid_bin_size = modHexDecode(public_uid_bin, (const uint8_t *)optarg, PUBLIC_UID_BYTE_SIZE, NULL);
                     getSHA256(public_uid_bin, public_uid_bin_size, (uint8_t *)&entry.public_uid_hash);
                     mode |= MODE_SEARCH_PUBLIC;
                 } else {

--- a/src/utils/ykpasswd.c
+++ b/src/utils/ykpasswd.c
@@ -157,7 +157,7 @@ void parseCommandLine(int argc, char *argv[]) {
 
 int getPublicUID(void) {
     if (NULL != otp)
-        parseOTP(&tkt, public_uid_bin, &public_uid_bin_size, (const uint8_t *)otp, NULL);
+        parseOTP(&tkt, public_uid_bin, &public_uid_bin_size, (const uint8_t *)otp, NULL, NULL);
         
     /* obtain the private_uid if not already defined and store the hash */
     if ( NULL == public_uid_text && public_uid_bin_size <= 0 ) {
@@ -174,13 +174,13 @@ int getPublicUID(void) {
 
             public_uid_bin_size = hexDecode(public_uid_bin, (const uint8_t *)public_uid_text, PUBLIC_UID_BYTE_SIZE);
         /* decode the public uid if in modhex format */
-        } else if ( ! checkModHexString((const uint8_t *)public_uid_text) ) {
+        } else if ( ! checkModHexString((const uint8_t *)public_uid_text, NULL) ) {
             if ( strlen(public_uid_text) > 32 ) {
                 printf("Public UID is too long! Max of 32 modhex chars allowed.\n");
                 return -1;
             }
 
-            public_uid_bin_size = modHexDecode(public_uid_bin, (const uint8_t *)public_uid_text, PUBLIC_UID_BYTE_SIZE);
+            public_uid_bin_size = modHexDecode(public_uid_bin, (const uint8_t *)public_uid_text, PUBLIC_UID_BYTE_SIZE, NULL);
         } else {
             printf("Public UID [%s] must be in hex format!\n", public_uid_text);
             return -1;
@@ -209,8 +209,8 @@ int addYubikeyEntry(void) {
     if (NULL != key_text) {
         if ( !checkHexString((const uint8_t *)key_text) )
             hexDecode((uint8_t *)&entry.ticket.key, (const uint8_t *)key_text, KEY_BYTE_SIZE);
-        else if ( ! checkModHexString((const uint8_t *)key_text) )
-            modHexDecode((uint8_t *)&entry.ticket.key, (const uint8_t *)key_text, KEY_BYTE_SIZE);
+        else if ( ! checkModHexString((const uint8_t *)key_text, NULL) )
+            modHexDecode((uint8_t *)&entry.ticket.key, (const uint8_t *)key_text, KEY_BYTE_SIZE, NULL);
         else {
             printf("Invalid key specified!\n");
             return -1;
@@ -224,7 +224,7 @@ int addYubikeyEntry(void) {
     /* with a valid key */
     if ( NULL != otp ) {
         /* decode the OTP */
-        if ( parseOTP(&tkt, public_uid_bin, &public_uid_bin_size, (const uint8_t *)otp, entry.ticket.key ) != 0 ) {
+        if ( parseOTP(&tkt, public_uid_bin, &public_uid_bin_size, (const uint8_t *)otp, entry.ticket.key, NULL) != 0 ) {
             printf("Invalid OTP specified!\n");
             return -1;
         }
@@ -261,8 +261,8 @@ int addYubikeyEntry(void) {
     if ( NULL != private_uid_text && private_uid_bin_size <= 0 ) {
         if ( ! checkHexString((const uint8_t *)private_uid_text) )
             hexDecode(private_uid_bin, (const uint8_t *)private_uid_text, PRIVATE_UID_BYTE_SIZE);
-        else if ( ! checkModHexString((const uint8_t *)private_uid_text) )
-            modHexDecode(private_uid_bin, (const uint8_t *)private_uid_text, PRIVATE_UID_BYTE_SIZE);
+        else if ( ! checkModHexString((const uint8_t *)private_uid_text, NULL) )
+            modHexDecode(private_uid_bin, (const uint8_t *)private_uid_text, PRIVATE_UID_BYTE_SIZE, NULL);
         else {
             printf("Invalid UID specified!\n");
             return -1;


### PR DESCRIPTION
This adds support for Dvorak and Colemak, and an easy way for users to add additional layouts that are not directly compatible with modhex.

The change is implemented by adding an array of modhex strings to src/utils/yk_chkpwd.c, and then looping over the array and authenticating if ANY of them can parse the OTP as valid, and fails only if none of them can.

Routines that handle OTP validation and parsing have been modified to take an additional parameter, trans, representing the translation string to use for the verification (eg, for modhex this would just be the MODHEX constant cbdefgh...)

To ensure that users enroll the key they intend to in the presence of two keymaps which are permutations of each other, ykpasswd will still only accept keys in modhex, and thus a script is provided to easily convert a OTP from any layout to modhex.
