### PR TITLE
Add no_passcode argument to prevent setting PAM_AUTHTOK

### DIFF
--- a/README
+++ b/README
@@ -74,6 +74,11 @@ Supported PAM module parameters are:
         can contain one user.
         Ex: exclude_users=/etc/yubikey.users
 
+  no_passcode
+	instructs the module to not save the pam authtok to allow for
+	two-factor authentication with other pam modules such as pam_ecryptfs
+	which is configured to use the user's passphrase.
+
   passcode_only
         instead of the OTP, pam authtok will only contain the
         passcode. This can be very handy when you are using other

--- a/src/pam_yubikey.c
+++ b/src/pam_yubikey.c
@@ -236,11 +236,11 @@ pam_sm_authenticate (pam_handle_t *pamh,
     }
 
     if (retval == EXIT_SUCCESS) {
-        if ((passcode_only != 0) && (passcode != NULL)) {
-            retval = pam_set_item(pamh, PAM_AUTHTOK, passcode);
-        } else {
-            retval = pam_set_item(pamh, PAM_AUTHTOK, otp_passcode);
-        }
+        /* if ((passcode_only != 0) && (passcode != NULL)) { */
+        /*     retval = pam_set_item(pamh, PAM_AUTHTOK, passcode); */
+        /* } else { */
+        /*     retval = pam_set_item(pamh, PAM_AUTHTOK, otp_passcode); */
+        /* } */
         if (retval != PAM_SUCCESS) {
             if (debug)
                 syslog(LOG_DEBUG, "set_item returned error: %s", pam_strerror (pamh, retval));

--- a/src/pam_yubikey.c
+++ b/src/pam_yubikey.c
@@ -160,6 +160,7 @@ pam_sm_authenticate (pam_handle_t *pamh,
     char *include_users = NULL;
     char *exclude_users = NULL;
     int passcode_only = 0;
+    int no_passcode = 0;
     int combined_passcode_otp = 0;
     int discreet_prompt = 0;
 
@@ -174,6 +175,8 @@ pam_sm_authenticate (pam_handle_t *pamh,
             exclude_users = index(argv[i], '=') + 1;
         else if (strncmp(argv[i], "passcode_only", 13) == 0)
             passcode_only = 1;
+	else if (strncmp(argv[i], "no_passcode", 11) == 0)
+            no_passcode = 1;
         else if (strncmp(argv[i], "combined_passcode_otp", 21) == 0)
             combined_passcode_otp = 1;
         else if (strncmp(argv[i], "discreet_prompt", 15) == 0)
@@ -236,16 +239,18 @@ pam_sm_authenticate (pam_handle_t *pamh,
     }
 
     if (retval == EXIT_SUCCESS) {
-        /* if ((passcode_only != 0) && (passcode != NULL)) { */
-        /*     retval = pam_set_item(pamh, PAM_AUTHTOK, passcode); */
-        /* } else { */
-        /*     retval = pam_set_item(pamh, PAM_AUTHTOK, otp_passcode); */
-        /* } */
-        if (retval != PAM_SUCCESS) {
-            if (debug)
-                syslog(LOG_DEBUG, "set_item returned error: %s", pam_strerror (pamh, retval));
-            return retval;
-        }
+	if (no_passcode == 0) {
+	    if ((passcode_only != 0) && (passcode != NULL)) {
+		retval = pam_set_item(pamh, PAM_AUTHTOK, passcode);
+	    } else {
+		retval = pam_set_item(pamh, PAM_AUTHTOK, otp_passcode);
+	    }
+	    if (retval != PAM_SUCCESS) {
+		if (debug)
+		    syslog(LOG_DEBUG, "set_item returned error: %s", pam_strerror (pamh, retval));
+		return retval;
+	    }
+	}
         return PAM_SUCCESS;
     }
     


### PR DESCRIPTION
I am attempting to use 2FA (Yubikey OTP & UNIX passphrase) as two separate modules so I push my Yubikey then type my password. This patch is needed to make sure that the PAM_AUTHTOK isn't set to the OTP or passcode by pam_yubikey and will hold the user's UNIX passphrase instead when pam_ecryptfs is used. When the no_passcode argument is passed, the calls to set_pam_item for the PAM_AUTHTOK are skipped.
